### PR TITLE
BUG: multiple fixes

### DIFF
--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -919,7 +919,7 @@ Disable if data is added or removed from the database."""
     rowIndex = self.studiesTableRowCount
     table.setRowCount(rowIndex + len(studies))
 
-    # from dicomweb_client.api import load_json_dataset
+    
     for study in studies:
       widget, value = self.setTableCellTextFromDICOM(table, self.studiesTableHeaderLabels, study, rowIndex, 'Study instance UID', '0020000D')
       self.studyInstanceUIDWidgets.append(widget)
@@ -947,11 +947,11 @@ Disable if data is added or removed from the database."""
     rowIndex = self.seriesTableRowCount
     table.setRowCount(rowIndex + len(series))
 
-    # from dicomweb_client.api import load_json_dataset
+    
     import dicomweb_client 
     from packaging import version 
     for serieJson in series:
-      # serie = load_json_dataset(serieJson)
+      
       if (version.parse(dicomweb_client.__version__) < version.parse("0.54")):
         from dicomweb_client.api import load_json_dataset
         serie = load_json_dataset(serieJson)
@@ -1097,7 +1097,7 @@ class GCPSelectorDialog(qt.QDialog):
 class GoogleCloudPlatform(object):
 
   def gcloud(self, subcommand):
-    # args = ['gcloud']
+   
     import shutil 
     args = [shutil.which('gcloud')]
     args.extend(subcommand.split())
@@ -1106,16 +1106,13 @@ class GoogleCloudPlatform(object):
     return process.stdout.read()
 
   def projects(self):
-    return self.gcloud("projects list --format=value(PROJECT_ID)").split("\n")[0:]
-    # return self.gcloud("projects list").split("\n")[1:]
+    return self.gcloud("projects list --format=value(PROJECT_ID)").split("\n")
 
   def datasets(self, project):
-    return self.gcloud(f"--project {project} healthcare datasets list --format=value(ID,LOCATION)").split("\n")[0:]
-    # return self.gcloud(f"--project {project} healthcare datasets list").split("\n")[1:]
+    return self.gcloud(f"--project {project} healthcare datasets list --format=value(ID,LOCATION)").split("\n")
 
   def dicomStores(self, project, dataset):
-    return self.gcloud(f"--project {project} healthcare dicom-stores list --dataset {dataset} --format=value(ID)").split("\n")[0:]
-    # return self.gcloud(f"--project {project} healthcare dicom-stores list --dataset {dataset}").split("\n")[1:]
+    return self.gcloud(f"--project {project} healthcare dicom-stores list --dataset {dataset} --format=value(ID)").split("\n")
 
   def token(self):
     return self.gcloud("auth print-access-token").strip()


### PR DESCRIPTION
With reference to: https://github.com/lassoan/SlicerDICOMwebBrowser/pull/7

I have made a number of changes with reference to the above pull request. This was only tested on a Windows machine, with Slicer version 4.11.20210226. 

1. I had to modify how the `gcloud` command was found

2. I added in checking of the `dicomweb_client` version to use either `load_json_dataset(serieJson)` if < 0.54 or  `pydicom.dataset.Dataset.from_json(serieJson)` if > 0.54. 

3. I added code so that the serverURL was populated, by adding this line `self.serverUrlLineEdit.currentText = qt.QSettings().value('DICOMwebBrowser/ServerURL', url) ` in `onGCPSelectorDialogFinished`

4. I modified how the projects, datasets and datastores were listed. The `gcloud` command on Windows results in separate lines  as seen in the image below. 
![listing_projects_windows_error](https://user-images.githubusercontent.com/59979551/151431405-c96c031d-6dce-4836-8130-e2913a099c1b.png)
When one project is clicked, it results in the following: 
![listing_projects_windows_error_2](https://user-images.githubusercontent.com/59979551/151431588-7929c467-43d3-4745-a110-457894f3afb9.png)
Instead, for listing the projects, we could format the output by using: `gcloud projects list --format="value(PROJECT_ID)" `
For the datasets and datastores, similar commands can be used.
 