### PR TITLE
Multiple fixes 

### DIFF
--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -949,14 +949,8 @@ Disable if data is added or removed from the database."""
 
     
     import dicomweb_client 
-    from packaging import version 
     for serieJson in series:
-      
-      if (version.parse(dicomweb_client.__version__) < version.parse("0.54")):
-        from dicomweb_client.api import load_json_dataset
-        serie = load_json_dataset(serieJson)
-      else:
-        serie = pydicom.dataset.Dataset.from_json(serieJson)
+      serie = pydicom.dataset.Dataset.from_json(serieJson)
       if hasattr(serie, 'SeriesInstanceUID'):
         widget, seriesInstanceUID = self.setTableCellTextFromDICOM(table, tableColumns, serie, rowIndex, 'Series Instance UID', 'SeriesInstanceUID')
         widget.setData(self.seriesItemSeriesInstanceUIDRole, serie.SeriesInstanceUID)

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -1093,7 +1093,7 @@ class GoogleCloudPlatform(object):
   def gcloud(self, subcommand):
    
     import shutil 
-    args = shutil.which('gcloud')
+    args = [shutil.which('gcloud')]
     if (None in args):
       logging.error(f"Unable to locate gcloud, please install the Google Cloud SDK")
     args.extend(subcommand.split())

--- a/DICOMwebBrowser/DICOMwebBrowser.py
+++ b/DICOMwebBrowser/DICOMwebBrowser.py
@@ -1093,7 +1093,9 @@ class GoogleCloudPlatform(object):
   def gcloud(self, subcommand):
    
     import shutil 
-    args = [shutil.which('gcloud')]
+    args = shutil.which('gcloud')
+    if (None in args):
+      logging.error(f"Unable to locate gcloud, please install the Google Cloud SDK")
     args.extend(subcommand.split())
     process = slicer.util.launchConsoleProcess(args)
     process.wait()


### PR DESCRIPTION
With reference to https://github.com/lassoan/SlicerDICOMwebBrowser/pull/7 

I made a few changes:
1. I put in the change to use `pydicom.dataset.Dataset.from_json` instead of relying on `load_json_dataset` 
2. I added in error reporting if gcloud is not found, please let me know if this is not sufficient.